### PR TITLE
feature: add webchat style options

### DIFF
--- a/packages/clova-chatbot-web-kit-bundle/src/WebChatContainer/WebChat.js
+++ b/packages/clova-chatbot-web-kit-bundle/src/WebChatContainer/WebChat.js
@@ -12,14 +12,50 @@ import {
 import { usePostMessage, useResponsive } from '../hooks'
 
 const Wrapper = styled.div`
+  /* part of bootstrap reboot.css https://raw.githubusercontent.com/twbs/bootstrap/v4-dev/dist/css/bootstrap-reboot.css*/
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  p {
+    margin-top: 0;
+    //margin-bottom: 1rem;
+  }
+  a {
+    color: #007bff;
+    text-decoration: none;
+    background-color: transparent;
+  }
+  a:hover {
+    color: #0056b3;
+    text-decoration: underline;
+  }
+  a:not([href]):not([class]) {
+    color: inherit;
+    text-decoration: none;
+  }
+  a:not([href]):not([class]):hover {
+    color: inherit;
+    text-decoration: none;
+  }
+  /* */
   position: relative;
   width: 100%;
   height: 100%;
   background-color: ${(props) => props.backgroundColor};
-  url(${(props) => `background-image: ${props.backgroundImage}`});
+  background-image: url(${(props) => props.backgroundImage});
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
+  border-top-left-radius: ${(props) =>
+    props.borderTopLeftRadius ? `${props.borderTopLeftRadius}` : `0`};
+  border-top-right-radius: ${(props) =>
+    props.borderTopRightRadius ? `${props.borderTopRightRadius}` : `0`};
+  border-bottom-left-radius: ${(props) =>
+    props.borderBottomLeftRadius ? `${props.borderBottomLeftRadius}` : `0`};
+  border-bottom-right-radius: ${(props) =>
+    props.borderBottomRightRadius ? `${props.borderBottomRightRadius}` : `0`};
   transition: all 0.3s ease-in-out;
   .web-chat-header {
     position: absolute;
@@ -67,6 +103,10 @@ const WebChat = (props) => {
     placeholder,
     backgroundColor,
     backgroundImage,
+    borderTopLeftRadius,
+    borderTopRightRadius,
+    borderBottomLeftRadius,
+    borderBottomRightRadius,
     headerHeight,
   } = styles
 
@@ -84,6 +124,10 @@ const WebChat = (props) => {
       headerHeight={headerHeight}
       backgroundColor={backgroundColor}
       backgroundImage={backgroundImage}
+      borderTopLeftRadius={borderTopLeftRadius}
+      borderTopRightRadius={borderTopRightRadius}
+      borderBottomLeftRadius={borderBottomLeftRadius}
+      borderBottomRightRadius={borderBottomRightRadius}
     >
       <WebChatHeader
         title={title}

--- a/packages/clova-chatbot-web-kit-components/src/components/WebChatHeader/index.js
+++ b/packages/clova-chatbot-web-kit-components/src/components/WebChatHeader/index.js
@@ -11,9 +11,14 @@ const Wrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   flex: 0 1 auto;
-  background-color: #303b51;
+  background-color: ${(props) =>
+    props.backgroundColor ? `${props.backgroundColor}` : `#303b51`};
   box-sizing: border-box;
   padding: 10px;
+  border-top-left-radius: ${(props) =>
+    props.borderTopLeftRadius ? `${props.borderTopLeftRadius}` : `0`};
+  border-top-right-radius: ${(props) =>
+    props.borderTopRightRadius ? `${props.borderTopRightRadius}` : `0`};
   overflow: hidden;
   :hover {
     cursor: pointer;
@@ -21,7 +26,7 @@ const Wrapper = styled.div`
 `
 
 const TitleWrapper = styled.div`
-  color: white;
+  color: ${(props) => (props.color ? `${props.color}` : `white`)};
 `
 
 const ActionList = styled.ul`
@@ -35,7 +40,7 @@ const ActionList = styled.ul`
     font-size: 20px;
     height: 1em;
     line-height: 1;
-    color: white;
+    color: ${(props) => (props.color ? `${props.color}` : `white`)};
     float: left;
     transition: all 0.3s;
     &:hover {
@@ -57,16 +62,26 @@ const propTypes = {
 const WebChatHeader = (props) => {
   const { title, onClose, onMinimize } = props
   const styles = useContext(StyleContext)
-  const { headerHeight } = styles
+  const {
+    headerHeight,
+    headerColor,
+    headerBackgroundColor,
+    borderTopLeftRadius,
+    borderTopRightRadius,
+  } = styles
 
   return (
     <Wrapper
       className="web-chat-header"
       height={headerHeight}
+      color={headerColor}
+      backgroundColor={headerBackgroundColor}
+      borderTopLeftRadius={borderTopLeftRadius}
+      borderTopRightRadius={borderTopRightRadius}
       onClick={onMinimize}
     >
-      <TitleWrapper>{title}</TitleWrapper>
-      <ActionList>
+      <TitleWrapper color={headerColor}>{title}</TitleWrapper>
+      <ActionList color={headerColor}>
         <li>
           <MdClose onClick={onClose} />
         </li>

--- a/packages/clova-chatbot-web-kit-components/src/components/WebChatSendBox/index.js
+++ b/packages/clova-chatbot-web-kit-components/src/components/WebChatSendBox/index.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { MdSend } from 'react-icons/md'
+import { StyleContext } from '../../context'
 
 const Wrapper = styled.div`
   display: flex;
@@ -11,6 +12,10 @@ const Wrapper = styled.div`
   height: 50px;
   width: 100%;
   background-color: white;
+  border-bottom-left-radius: ${(props) =>
+    props.borderBottomLeftRadius ? `${props.borderBottomLeftRadius}` : `0`};
+  border-bottom-right-radius: ${(props) =>
+    props.borderBottomRightRadius ? `${props.borderBottomRightRadius}` : `0`};
   box-sizing: border-box;
 `
 
@@ -49,6 +54,8 @@ const propTypes = {
 const WebChatSendBox = (props) => {
   const { userId, placeholder, onSendMessage } = props
   const [text, setText] = useState('')
+  const styles = useContext(StyleContext)
+  const { borderBottomLeftRadius, borderBottomRightRadius } = styles
 
   const handleChange = (e) => {
     setText(e.target.value)
@@ -63,7 +70,7 @@ const WebChatSendBox = (props) => {
     }
   }
 
-  const handleSendMessage = (e) => {
+  const handleSendMessage = () => {
     if (text === '') return
 
     onSendMessage({ userId, text })
@@ -71,7 +78,11 @@ const WebChatSendBox = (props) => {
   }
 
   return (
-    <Wrapper className="web-chat-send-box">
+    <Wrapper
+      className="web-chat-send-box"
+      borderBottomLeftRadius={borderBottomLeftRadius}
+      borderBottomRightRadius={borderBottomRightRadius}
+    >
       <MessageInput
         placeholder={placeholder}
         value={text}

--- a/packages/clova-chatbot-web-kit-components/src/context/StyleContext.js
+++ b/packages/clova-chatbot-web-kit-components/src/context/StyleContext.js
@@ -8,7 +8,13 @@ export const defaultStyles = {
   placeholder: 'Do you have any questions?',
   backgroundColor: '#7793bf',
   backgroundImage: '',
+  borderTopLeftRadius: '',
+  borderTopRightRadius: '',
+  borderBottomRightRadius: '',
+  borderBottomLeftRadius: '',
   headerHeight: '50px',
+  headerColor: '#ffffff',
+  headerBackgroundColor: '#303b51',
   avatarBackgroundColor: '#bbbfc3',
   avatarImage: '',
   bubbleStyle: 'rounded', // [rounded, square]


### PR DESCRIPTION
**The following options are now available for webChat.renderWebChat().**
- Making the appearance of the web chat rounded corners
- Specifying the background color of the web chat header
- Specifying the text color of the web chat header

**Configuration example**
```
WebChat.renderWebChat(
   {
    borderTopLeftRadius: ‘10px’,
    borderTopRightRadius: ‘10px’,
    borderBottomRightRadius: ‘10px’,
    borderBottomLeftRadius: ‘10px’,
    headerColor: “#FFFFFF”,
    headerBackgroundColor: “#333333",
  }
)
```