### PR TITLE
Added option to inject color settings for links and buttons

### DIFF
--- a/examples/1.getting-started/README.md
+++ b/examples/1.getting-started/README.md
@@ -34,7 +34,7 @@ Properties of `webchat.js` are defined in [main.js](main.js). In this sample, th
 All properties are shown in the table below.
 
 | Property                  | Description                                                             |
-| ------------------------- | ----------------------------------------------------------------------- |
+|---------------------------|-------------------------------------------------------------------------|
 | apiPath                   | Proxy server path                                                       |
 | width                     | Chat box width                                                          |
 | height                    | Chat box height                                                         |
@@ -44,7 +44,7 @@ All properties are shown in the table below.
 | backgroundColor           | Chat box background color                                               |
 | backgroundImage           | Chat box background image                                               |
 | avatarBackgroundColor     | Avatar background color                                                 |
-| avatarImage　　　　　　　　　　　　　　　　　　　　     | Avatar background image                                                 |
+| avatarImage               | Avatar background image                                                 |
 | bubbleStyle               | Default bubble edge style ( `rounded` or `square`)                      |
 | bubbleRadius              | Default bubble edge rounding when `bubbleStyle` is `rounded`            |
 | bubbleColor               | Default bubble font color                                               |
@@ -59,8 +59,12 @@ All properties are shown in the table below.
 | borderTopRightRadius      | Radius of the Top-Right                                                 |
 | borderBottomRightRadius   | Radius of the Bottom-left                                               |
 | borderBottomLeftRadius    | Radius of the Bottom-Right                                              |
-| headerColor               | Header color                                                            |
+| headerColor               | Header font color                                                       |
 | headerBackgroundColor     | Header background color                                                 |
+| buttonColor               | Button font color                                                       |
+| buttonBackgroundColor     | Button background color                                                 |
+| linkColor                 | Link font color                                                         |
+| linkHoverColor            | Link font color when hovered                                            |
 
 # Events
 

--- a/packages/clova-chatbot-web-kit-bundle/src/WebChatContainer/WebChat.js
+++ b/packages/clova-chatbot-web-kit-bundle/src/WebChatContainer/WebChat.js
@@ -23,12 +23,12 @@ const Wrapper = styled.div`
     //margin-bottom: 1rem;
   }
   a {
-    color: #007bff;
+    color: ${(props) => props.linkColor};
     text-decoration: none;
     background-color: transparent;
   }
   a:hover {
-    color: #0056b3;
+    color: ${(props) => props.linkHoverColor};
     text-decoration: underline;
   }
   a:not([href]):not([class]) {
@@ -108,6 +108,8 @@ const WebChat = (props) => {
     borderBottomLeftRadius,
     borderBottomRightRadius,
     headerHeight,
+    linkColor,
+    linkHoverColor,
   } = styles
 
   const isMobile = useMediaQuery({ query: '(max-width: 575px)' })
@@ -128,6 +130,8 @@ const WebChat = (props) => {
       borderTopRightRadius={borderTopRightRadius}
       borderBottomLeftRadius={borderBottomLeftRadius}
       borderBottomRightRadius={borderBottomRightRadius}
+      linkColor={linkColor}
+      linkHoverColor={linkHoverColor}
     >
       <WebChatHeader
         title={title}

--- a/packages/clova-chatbot-web-kit-components/src/components/Button/index.js
+++ b/packages/clova-chatbot-web-kit-components/src/components/Button/index.js
@@ -11,11 +11,11 @@ const Wrapper = styled.div`
   margin: 0;
   word-break: break-all;
   overflow: hidden;
-  background-color: azure;
-  border-top: 1px solid #eee;
+  background-color: ${(props) => props.backgroundColor};
+  border-top: 1px solid rgba(255, 255, 255, 0.5);
   padding: 10px 16px;
   font-size: ${(props) => props.fontSize};
-  color: #007bff;
+  color: ${(props) => props.color};
   .icon {
     display: inline-block;
     position: absolute;
@@ -29,7 +29,7 @@ const Wrapper = styled.div`
   transition: all 0.2s ease-in-out;
   :hover {
     cursor: pointer;
-    color: #0056b3;
+    opacity: 0.9;
   }
 `
 
@@ -52,11 +52,15 @@ const Button = (props) => {
   const { userId, title, data, onSendMessage } = props
   const [onAction] = useAction({ userId, onSendMessage })
   const styles = useContext(StyleContext)
-  const { bubbleFontSize } = styles
+  const { bubbleFontSize, buttonColor, buttonBackgroundColor } = styles
 
   if (data && data.action) {
     return (
-      <Wrapper fontSize={bubbleFontSize}>
+      <Wrapper
+        fontSize={bubbleFontSize}
+        color={buttonColor}
+        backgroundColor={buttonBackgroundColor}
+      >
         <div onClick={() => onAction(data)}>
           <MdKeyboardArrowRight className="icon" />
           <p>{title}</p>

--- a/packages/clova-chatbot-web-kit-components/src/context/StyleContext.js
+++ b/packages/clova-chatbot-web-kit-components/src/context/StyleContext.js
@@ -27,6 +27,10 @@ export const defaultStyles = {
   userBubbleColor: '',
   userBubbleBackgroundColor: '',
   userBubbleFontSize: '',
+  buttonColor: '#007bff',
+  buttonBackgroundColor: '#f0ffff',
+  linkColor: '#007bff',
+  linkHoverColor: '#0056b3',
 }
 
 export const StyleContext = React.createContext(defaultStyles)


### PR DESCRIPTION
```
  WebChat.renderWebChat(
    {
      apiPath: 'http://localhost:4010/',
      width: '360px',
      height: '550px',
      title: 'CLOVA Chatbot!',
      placeholder: "Do you have any questions?",
      backgroundColor: "#7793bf",
      backgroundImage: "",
      avatarBackgroundColor: "#bbbfc3",
      avatarImage: "",
      bubbleStyle: "rounded", // [rounded, square]
      bubbleRadius: "12px",
      bubbleColor: "rgb(80,80,80)",
      bubbleBackgroundColor: "rgb(243,243,237)",
      bubbleFontSize: "14px",
      userBubbleStyle: 'rounded', // [rounded, square]
      userBubbleRadius: '12px',
      userBubbleColor: 'rgb(80,80,80)',
      userBubbleBackgroundColor: '#3cd77d',
      userBubbleFontSize: '14px',
      buttonColor: '#ffffff',
      buttonBackgroundColor: '#4b5882',
      linkColor: '#007bff',
      linkHoverColor: '#0056b3',
    },
    document.querySelector(chatContainer)
  );
```
<img width="1199" alt="スクリーンショット 2022-05-18 12 16 25" src="https://user-images.githubusercontent.com/1168878/168950035-d7bd130a-8d11-471b-8a20-305236b23d87.png">
